### PR TITLE
Retain title as field original-title

### DIFF
--- a/bin/collect-links.js
+++ b/bin/collect-links.js
@@ -79,6 +79,7 @@ class App {
 							url: normalizedUrl,
 							"url-hash": hashedNormalizedUrl,
 							tags: stringifyList(filteredTags),
+							"original-title": fields.title, 
 							origin: siteInfo.name
 						})
 					}


### PR DESCRIPTION
Retaining the original title may provide an alternative display mechanism for search, topic displays, etc. (possibly as a configuration option). I know many of the original titles are not that meaningful, but if it doesn't turn out to be useful, it could be easily rolled back.