### PR TITLE
Topic mapping.

### DIFF
--- a/app-wiki/tiddlers/app/system/TopicsMap.txt
+++ b/app-wiki/tiddlers/app/system/TopicsMap.txt
@@ -1,0 +1,11 @@
+# "old topic", "mapped topic"
+"Example wiki", "Example"
+Examples, Example 
+examples, Example
+MarkDown, Markdown
+markdown, Markdown
+node.js, Node.js 
+nodejs, Node.js
+plugin, Plugin
+Plugins, Plugin
+plugins, Plugin

--- a/app-wiki/tiddlers/app/system/TopicsMap.txt.meta
+++ b/app-wiki/tiddlers/app/system/TopicsMap.txt.meta
@@ -1,0 +1,5 @@
+created: 20220516171708086
+modified: 20220516185144890
+tags: 
+title: Topics Map
+type: text/plain

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "csv-parse": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.0.4.tgz",
+      "integrity": "sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ=="
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Collecting TiddlyWiki Links",
   "dependencies": {
+    "csv-parse": "^5.0.4",
     "node-fetch": "^2.6.7",
     "normalize-url": "^5.3.1",
     "tiddlywiki": "github:Jermolene/TiddlyWiki5"


### PR DESCRIPTION
I know a full-fledged interface would be great, but until then, perhaps this could work?

This uses a text tiddler with CSV entries formatted simply like:

![image](https://user-images.githubusercontent.com/8988994/168669385-b6c7591e-688d-44c5-84eb-fda093736a1c.png)

It uses the csv-parse package to parse the entries and create a Topic dictionary object. This is then used to map incoming links.

Participants would simply make changes to the Topics Map, save and submit via github. Whenever the system is updated, the new mappings would be applied.

Concerns: 

Adding new dependency ok?
The object isn't built asynchronously. However, it should take about a couple thousandths of a second to create, so hopefully that will be ok.