### PR TITLE
Disable http-server cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "collect-links": "node ./bin/collect-links.js",
     "build-dist": "npx tiddlywiki app-wiki --output dist --build index",
     "edit": "npx tiddlywiki +plugins/tiddlywiki/filesystem +plugins/tiddlywiki/tiddlyweb app-wiki --listen port=0",
-    "serve": "npx http-server ./dist",
+    "serve": "npx http-server ./dist -c-1",
     "test": "node bin/test.js"
   },
   "author": "Jeremy Ruston",


### PR DESCRIPTION
When testing I was surprised that the server kept showing me the unchanged index.html. It turns out the default cache is 3600 seconds (1 hour). For local running, the cache doesn't seem to be needed. This change adds the option to disable the cache.