### PR TITLE
Make search look more like a search

### DIFF
--- a/app-wiki/tiddlers/app/system/Startup Settings.tid
+++ b/app-wiki/tiddlers/app/system/Startup Settings.tid
@@ -1,7 +1,8 @@
 created: 20220513192040502
-modified: 20220513192115216
+modified: 20220521183547930
 tags: $:/tags/StartupAction
 title: Startup Settings
 type: text/vnd.tiddlywiki
 
 <$action-setfield $tiddler="$:/state/sidebar" text=“no” />
+<$action-setfield $tiddler="$:/temp/search" text="cloud"/>

--- a/app-wiki/tiddlers/app/templates/Styles.tid
+++ b/app-wiki/tiddlers/app/templates/Styles.tid
@@ -1,5 +1,5 @@
 created: 20220423154207929
-modified: 20220515025027568
+modified: 20220521183312503
 tags: $:/tags/Stylesheet
 title: $:/_Styles
 type: text/vnd.tiddlywiki
@@ -169,8 +169,17 @@ Search
 	box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.3);
 }
 
-.tc-link-search {
-width: 100% ;
+div.tc-link-search {
+  display: flex;
+  align-items: flex-start;
+}
+div.tc-link-search input {
+  flex: 1; /*take all the available space*/
+  max-width: 25em ;
+}
+div.tc-link-search  span{
+padding-left: 7px;
+padding-right: 7px;
 }
 
 table.tc-search-options td, table.tc-search-options {

--- a/app-wiki/tiddlers/app/top-level-pages/Search.tid
+++ b/app-wiki/tiddlers/app/top-level-pages/Search.tid
@@ -1,5 +1,5 @@
 created: 20220420182241970
-modified: 20220515185808654
+modified: 20220521182440667
 search-mode: normal
 tags: 
 title: Search
@@ -19,7 +19,9 @@ type: text/vnd.tiddlywiki
 </tr>
 </table>
 
-<$edit-text tiddler="$:/temp/search" field="text" tag="input" class="tc-link-search"/> 
+<div class="tc-link-search">
+<span>''Search:''</span><$edit-text tiddler="$:/temp/search" field="text" tag="input" xclass="tc-link-search"/> 
+</div>
 
 <$vars limit={{{ [{$:/temp/search}length[]compare:integer:lt[3]then[5]else[100]] }}}>
 <$let


### PR DESCRIPTION
It appeared to me that people were failing to recognize that the page was opening on an actual search engine. This change floats the word "Search" next to the search box, shrinks the search box so that it doesn't look like part of the decor, and provides a default search term ("cloud") so it can be immediately seen in action.