### PR TITLE
Add 'original-title' to search

### DIFF
--- a/app-wiki/tiddlers/app/top-level-pages/Search.tid
+++ b/app-wiki/tiddlers/app/top-level-pages/Search.tid
@@ -1,6 +1,6 @@
 created: 20220420182241970
-modified: 20220521182440667
-search-mode: normal
+modified: 20230809005417739
+search-mode: regexp
 tags: 
 title: Search
 title-type: pseudo
@@ -26,8 +26,8 @@ type: text/vnd.tiddlywiki
 <$vars limit={{{ [{$:/temp/search}length[]compare:integer:lt[3]then[5]else[100]] }}}>
 <$let
 subfilter="[tag[$:/tags/Link]]" 
-searchNormal="[search:text{$:/temp/search}]"
-searchRegexp="[regexp:text{$:/temp/search}]"
+searchNormal="[search:text,original-title{$:/temp/search}]"
+searchRegexp="[regexp:text{$:/temp/search}][regexp:original-title{$:/temp/search}]"
 searchFilter= {{{ [{Search!!search-mode}match[normal]then<searchNormal>else<searchRegexp>] }}}
 >
 <$list filter="[subfilter<subfilter>subfilter<searchFilter>limit<limit>]">

--- a/app-wiki/tiddlers/app/top-level-pages/Search.tid
+++ b/app-wiki/tiddlers/app/top-level-pages/Search.tid
@@ -1,6 +1,6 @@
 created: 20220420182241970
-modified: 20230809005417739
-search-mode: regexp
+modified: 20230809030023549
+search-mode: normal
 tags: 
 title: Search
 title-type: pseudo


### PR DESCRIPTION
Sometimes the original title contains keywords that aren't actually in the description. This change increases the odds that those terms will find a match.