### PR TITLE
Fix conflict between dynannotate styles and Cupertino dark palette

### DIFF
--- a/app-wiki/tiddlers/app/templates/Styles.tid
+++ b/app-wiki/tiddlers/app/templates/Styles.tid
@@ -1,12 +1,25 @@
 created: 20220423154207929
-modified: 20220521183312503
+modified: 20230809174816117
 tags: $:/tags/Stylesheet
 title: $:/_Styles
 type: text/vnd.tiddlywiki
 
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
+\define dynannotate-dark-styles() 
+<$list filter="[{$:/palette}match[$:/palettes/CupertinoDark]]"> 
+.tc-link-panel > .tc-link-panel-body {
+	background: #3f638b  ;
+	padding: 0.5em;
+}
 
+.tc-dynannotate-snippet-context::selection {
+  	background-color: lightgray ;
+	color: black;
+} 
+
+</$list>
+\end
 
 /*
 Rich links
@@ -144,9 +157,15 @@ Details
 }
 
 .tc-link-panel > .tc-link-panel-body {
-	background: #fff;
+	background: #fff ;
 	padding: 0.5em;
 }
+
+<<dynannotate-dark-styles>>
+
+/*  zzz */
+
+
 /*
 Search
 */
@@ -184,4 +203,8 @@ padding-right: 7px;
 
 table.tc-search-options td, table.tc-search-options {
 border: none; 
+}
+
+.tc-dynannotate-snippet-highlight {
+color: black ;
 }

--- a/app-wiki/tiddlers/app/templates/Styles.tid
+++ b/app-wiki/tiddlers/app/templates/Styles.tid
@@ -1,5 +1,5 @@
 created: 20220423154207929
-modified: 20230809180217272
+modified: 20230809180543262
 tags: $:/tags/Stylesheet
 title: $:/_Styles
 type: text/vnd.tiddlywiki
@@ -17,7 +17,9 @@ type: text/vnd.tiddlywiki
   	background-color: lightgray ;
 	color: black;
 } 
-
+.tc-dynannotate-snippet-highlight {
+color: black ;
+}
 </$list>
 \end
 
@@ -202,6 +204,3 @@ table.tc-search-options td, table.tc-search-options {
 border: none; 
 }
 
-.tc-dynannotate-snippet-highlight {
-color: black ;
-}

--- a/app-wiki/tiddlers/app/templates/Styles.tid
+++ b/app-wiki/tiddlers/app/templates/Styles.tid
@@ -1,5 +1,5 @@
 created: 20220423154207929
-modified: 20230809174816117
+modified: 20230809180217272
 tags: $:/tags/Stylesheet
 title: $:/_Styles
 type: text/vnd.tiddlywiki
@@ -157,14 +157,11 @@ Details
 }
 
 .tc-link-panel > .tc-link-panel-body {
-	background: #fff ;
+	background: #fff;
 	padding: 0.5em;
 }
 
 <<dynannotate-dark-styles>>
-
-/*  zzz */
-
 
 /*
 Search


### PR DESCRIPTION
It turns out that Cupertino dark doesn't play nicely with the default dynannotate styles. After trying several approaches, I added dynamic styles to the main links stylesheet. This assures that the Cupertino will look good (I hope) , and the other palettes are unaffected one way or the other.