### PR TITLE
Reconfigure search results for rapid access.

### DIFF
--- a/app-wiki/tiddlers/app/templates/Components/LinkPanelSearch.tid
+++ b/app-wiki/tiddlers/app/templates/Components/LinkPanelSearch.tid
@@ -1,5 +1,5 @@
 created: 20220420192043799
-modified: 20220515184018920
+modified: 20230812005113559
 tags: 
 title: $:/_Templates/Components/LinkPanelSearch
 type: text/vnd.tiddlywiki
@@ -18,6 +18,7 @@ Parameters:
 """
 pseudo={{{ [<currentTiddler>get[text]splitregexp<linereturn>search-replace:im:regexp<splithere>,[$1]] }}}
 workingTitle={{{ [{Search!!title-type}match[original]then{!!original-title}else<pseudo>] }}}
+tv-ellipsis={{{ [{Search!!title-type}match[original]then[]else[...]] }}}
 >
 <div class="tc-link-panel">
 <div class="tc-link-panel-heading">
@@ -26,10 +27,13 @@ workingTitle={{{ [{Search!!title-type}match[original]then{!!original-title}else<
 </$list>
 </div>
 <div class="tc-link-panel-body">
-<$dynannotate search={{$:/temp/search}} searchDisplay="snippet" 
-searchMode={{Search!!search-mode}}
+<$dynannotate 
+   search={{$:/temp/search}} 
+   searchDisplay="snippet" 
+   snippetContextLength=60
+   searchMode={{Search!!search-mode}}
 >
-<$transclude mode="inline"/>
+   <$transclude mode="inline"/>
 </$dynannotate>
 </div>
 </div>

--- a/app-wiki/tiddlers/app/templates/Components/LinksTagTemplate.tid
+++ b/app-wiki/tiddlers/app/templates/Components/LinksTagTemplate.tid
@@ -1,0 +1,23 @@
+created: 20230813003423274
+modified: 20230813192650652
+tags: 
+title: $:/Links-TagTemplate
+type: text/vnd.tiddlywiki
+
+\import [[$:/macro-list-tagged-draggable-for-original-title]]
+\whitespace trim
+<span class="tc-tag-list-item" data-tag-title=<<currentTiddler>>>
+<$set name="transclusion" value=<<currentTiddler>>>
+<$macrocall $name="tag-pill-body" tag=<<currentTiddler>> icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}} colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}} palette={{$:/palette}} element-tag="""$button""" element-attributes="""popup=<<qualify "$:/state/popup/tag">> dragFilter='[all[current]tagging[]]' tag='span'"""/>
+<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes" class="tc-drop-down">
+<$set name="tv-show-missing-links" value="yes">
+<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+</$set>
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/TagDropdown]!has[draft.of]]" variable="listItem"> 
+<$transclude tiddler=<<listItem>>/> 
+</$list>
+<hr>
+<$macrocall $name="list-tagged-draggable" tag=<<currentTiddler>> subFilter="sort[original-title]"/>
+</$reveal>
+</$set>
+</span>

--- a/app-wiki/tiddlers/app/templates/Components/MacroListTaggedDraggableForOriginalTitle.tid
+++ b/app-wiki/tiddlers/app/templates/Components/MacroListTaggedDraggableForOriginalTitle.tid
@@ -1,0 +1,34 @@
+created: 20230813003249302
+modified: 20230813192530457
+tags: 
+title: $:/macro-list-tagged-draggable-for-original-title
+type: text/vnd.tiddlywiki
+
+\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",storyview:"")
+\whitespace trim
+<span class="tc-tagged-draggable-list">
+<$set name="tag" value=<<__tag__>>>
+<$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>> storyview=<<__storyview__>>>
+<$elementTag$ class="tc-menu-list-item">
+<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" enable=<<tv-enable-drag-and-drop>>>
+<$elementTag$ class="tc-droppable-placeholder"/>
+<$elementTag$>
+<$transclude tiddler="""$itemTemplate$""">
+<$link to={{!!title}}>
+<$view field="original-title"/>
+</$link>
+</$transclude>
+</$elementTag$>
+</$droppable>
+</$elementTag$>
+</$list>
+<$tiddler tiddler="">
+<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" enable=<<tv-enable-drag-and-drop>>>
+<$elementTag$ class="tc-droppable-placeholder"/>
+<$elementTag$ style="height:0.5em;">
+</$elementTag$>
+</$droppable>
+</$tiddler>
+</$set>
+</span>
+\end

--- a/app-wiki/tiddlers/app/templates/RichLink/RichTitleLink.tid
+++ b/app-wiki/tiddlers/app/templates/RichLink/RichTitleLink.tid
@@ -1,10 +1,26 @@
 created: 20220421151132670
-modified: 20220514190910995
+modified: 20230812005730813
 title: $:/_Templates/RichTitle/Link
 type: text/vnd.tiddlywiki
 
-<div class="tc-richlink tc-richlink-link">
-<$link class="tc-richlink-link-info" title="Show link info"><$text text={{{[<workingTitle>addsuffix[...]]}}}/></$link> 
+<div class="tc-richlink tc-richlink-link ">
+<a href={{!!url}} target="_blank" rel="noopener noreferrer" class="tc-richlink-link-target" title={{!!url}}>{{$:/core/images/open-window}}</a>
+
+<a href={{!!url}} 
+   class="tc-richlink-link-info tc-tiddlylink tc-tiddlylink-resolves "  
+   target="_blank" rel="noopener noreferrer" 
+ ><$text text={{{[<workingTitle>addsuffix<tv-ellipsis>]}}}/></a> 
+
+<$link 
+  to=<<currentTiddler>>
+  class="tc-richlink-link-info " 
+  tooltip="Show link info">{{$:/core/images/info-button}}
+</$link> 
+
 (<$count filter="[url{!!url}]"/>)
-<a href={{!!url}} target="_blank" rel="noopener noreferrer" class="tc-richlink-link-target" title={{!!url}}>{{$:/core/images/open-window}}</a><a href={{{ [<download-link-template>encodeuricomponent[]addprefix[data:text/plain,]] }}} download={{{ [<link-title>get[url-hash]addprefix[link-]addsuffix[.tid]] }}} class="tc-richlink-link-download" title="Download this link as a tiddler to add to your own TiddlyWiki">{{$:/core/images/download-button}}</a>
+
+<div class="tc-tags-wrapper"><$list filter="[all[current]tags[]sort[title]]-$:/tags/Link" template="$:/core/ui/TagTemplate" storyview="pop"/></div>
+<div class="tc-subtitle">
+//Submitted by <$view field="origin"/> on <$view field="modified" format="date" template={{$:/language/Tiddler/DateFormat}}/>//
+</div>
 </div>

--- a/app-wiki/tiddlers/app/templates/RichLink/RichTitleLink.tid
+++ b/app-wiki/tiddlers/app/templates/RichLink/RichTitleLink.tid
@@ -1,5 +1,5 @@
 created: 20220421151132670
-modified: 20230812005730813
+modified: 20230813192731115
 title: $:/_Templates/RichTitle/Link
 type: text/vnd.tiddlywiki
 
@@ -19,7 +19,7 @@ type: text/vnd.tiddlywiki
 
 (<$count filter="[url{!!url}]"/>)
 
-<div class="tc-tags-wrapper"><$list filter="[all[current]tags[]sort[title]]-$:/tags/Link" template="$:/core/ui/TagTemplate" storyview="pop"/></div>
+<div class="tc-tags-wrapper"><$list filter="[all[current]tags[]sort[title]]-$:/tags/Link" template="$:/Links-TagTemplate" storyview="pop"/></div>
 <div class="tc-subtitle">
 //Submitted by <$view field="origin"/> on <$view field="modified" format="date" template={{$:/language/Tiddler/DateFormat}}/>//
 </div>

--- a/app-wiki/tiddlers/app/templates/Styles.tid
+++ b/app-wiki/tiddlers/app/templates/Styles.tid
@@ -1,5 +1,5 @@
 created: 20220423154207929
-modified: 20230809180543262
+modified: 20230812003929766
 tags: $:/tags/Stylesheet
 title: $:/_Styles
 type: text/vnd.tiddlywiki
@@ -19,6 +19,11 @@ type: text/vnd.tiddlywiki
 } 
 .tc-dynannotate-snippet-highlight {
 color: black ;
+}
+
+a.tc-richlink-link-target:visited svg {
+  fill: lightgray;
+
 }
 </$list>
 \end
@@ -50,6 +55,11 @@ tc-richlink-contributor-name {
 .tc-richlink-link {
 	
 }
+
+.tc-richlink div.tc-tags-wrapper {
+	margin: 0 0 0 0 ;
+}
+
 
 .tc-richlink-link-info {
 	word-break: break-all;

--- a/app-wiki/tiddlers/app/top-level-pages/Search.tid
+++ b/app-wiki/tiddlers/app/top-level-pages/Search.tid
@@ -1,5 +1,5 @@
 created: 20220420182241970
-modified: 20230812005753928
+modified: 20230813191116154
 search-mode: normal
 tags: 
 title: Search

--- a/app-wiki/tiddlers/app/top-level-pages/Search.tid
+++ b/app-wiki/tiddlers/app/top-level-pages/Search.tid
@@ -1,9 +1,9 @@
 created: 20220420182241970
-modified: 20230809030023549
+modified: 20230812005753928
 search-mode: normal
 tags: 
 title: Search
-title-type: pseudo
+title-type: original
 type: text/vnd.tiddlywiki
 
 <table class="tc-search-options"><tr>


### PR DESCRIPTION
This is a reconfiguration of the initial search results, emphasising quick access to the underlying url, increasing the amount of descriptive text displayed, associated tags, submission, and leveraging original titles for tag drop-down. This is per a conversation in the forums with input especially from _Dave Gifford_ and _vilc_.

The overall idea is to provide more information for the user to decide "this is the link" I want and make it more likely they will click on that link. 

![image](https://github.com/TiddlyWiki/TiddlyWikiLinks/assets/8988994/3d012e8a-2c25-47b8-8129-9caa69d7fc1a)
