### PR TITLE
Use Github official deploy actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,10 +23,10 @@ jobs:
         run: npm test
       - name: Build Site
         run: npm run build
-      - name: Deploy Content
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
-          token: ${{ secrets.GITHUBPUSHTOKEN }}
-          branch: main
-          repository-name: 'TiddlyWiki/links.tiddlywiki.org-gh-pages'
-          folder: dist
+          path: ./dist
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.4


### PR DESCRIPTION
This will publish gh-pages in this repo.

You only need to config it here:

![截屏2023-10-10 19 44 27](https://github.com/TiddlyWiki/TiddlyWikiLinks/assets/3746270/7378036a-4a26-4db1-954c-af6f8958f251)

Also, you may need to rebind domain from gh-pages of https://github.com/TiddlyWiki/links.tiddlywiki.org-gh-pages to gh-pages of this repo.

This can prevent your contribution graph covered with these auto commits, and people can't know what you actually working on.