### PR TITLE
Use Github official deploy actions + Fix id-token write

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,10 +23,10 @@ jobs:
         run: npm test
       - name: Build Site
         run: npm run build
-      - name: Deploy Content
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
-          token: ${{ secrets.GITHUBPUSHTOKEN }}
-          branch: main
-          repository-name: 'TiddlyWiki/links.tiddlywiki.org-gh-pages'
-          folder: dist
+          path: ./dist
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron:  '*/17 * * * *'
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sorry for the inconvenience, forget to add the permission part...

fix a bug in https://github.com/TiddlyWiki/TiddlyWikiLinks/pull/56

also, don't forget to turn on GitHub pages deploy by actions.